### PR TITLE
Integrate mailcatcher with php

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,3 +16,5 @@
   systemd: name=php71-php-fpm state=restarted
 - name: php72
   systemd: name=php72-php-fpm state=restarted
+- name: mailcatcher
+  systemd: name=mailcatcher state=restarted

--- a/tasks/fedora.yml
+++ b/tasks/fedora.yml
@@ -119,6 +119,7 @@
   template: src=templates/mailcatcher/mailcatcher.service.j2 dest=/usr/lib/systemd/system/mailcatcher.service
   notify:
     - systemd
+    - mailcatcher
 - name: Run mailcatcher service
   systemd: name=mailcatcher enabled=true state=started
 

--- a/templates/php/99-local.ini.j2
+++ b/templates/php/99-local.ini.j2
@@ -6,3 +6,4 @@ memory_limit = 2G
 post_max_size = 256M
 upload_max_filesize = 256M
 xdebug.remote_enable = 1
+sendmail_path = /usr/local/bin/catchmail -f me@localhost

--- a/templates/php/www.local.conf.j2
+++ b/templates/php/www.local.conf.j2
@@ -7,3 +7,5 @@ listen = 127.0.0.1:{{ php_fpm_port }}
 
 listen.acl_users = nginx
 listen.allowed_clients = 127.0.0.1
+
+php_admin_value[sendmail_path] = /usr/local/bin/catchmail -f me@localhost


### PR DESCRIPTION
Now when using PHP mail functionality, mails end up in the mailcatcher. This fixes #16.