### PR TITLE
Set ~/.my.cnf protocol to TCP

### DIFF
--- a/templates/mariadb/.my.cnf.j2
+++ b/templates/mariadb/.my.cnf.j2
@@ -1,3 +1,4 @@
 [client]
 user=root
 password={{ mysql_root_password }}
+protocol=TCP


### PR DESCRIPTION
Useful when application default to localhost as host, but should connect using TCP.